### PR TITLE
Make a stopped cart resume in its last direction.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -45,6 +45,7 @@ boost_cart.cart = {
 	punched = false, -- used to re-send velocity and position
 	velocity = {x=0, y=0, z=0}, -- only used on punch
 	old_dir = {x=0, y=0, z=0},
+	last_nonzero_dir = {x=1, y=0, z=0},
 	old_pos = nil,
 	old_switch = 0,
 	railtype = nil,
@@ -75,11 +76,15 @@ function boost_cart.cart:on_activate(staticdata, dtime_s)
 		return
 	end
 	self.railtype = data.railtype
+	if data.last_nonzero_dir then
+		self.last_nonzero_dir = data.last_nonzero_dir
+	end
 end
 
 function boost_cart.cart:get_staticdata()
 	return minetest.serialize({
-		railtype = self.railtype
+		railtype = self.railtype,
+		last_nonzero_dir = self.last_nonzero_dir,
 	})
 end
 
@@ -92,7 +97,7 @@ function boost_cart.cart:on_punch(puncher, time_from_last_punch, tool_capabiliti
 	end
 
 	if not puncher or not puncher:is_player() then
-		local cart_dir = boost_cart:get_rail_direction(pos, {x=1, y=0, z=0}, nil, nil, self.railtype)
+		local cart_dir = boost_cart:get_rail_direction(pos, self.last_nonzero_dir, nil, nil, self.railtype)
 		if vector.equals(cart_dir, {x=0, y=0, z=0}) then
 			return
 		end
@@ -283,6 +288,9 @@ function boost_cart.cart:on_step(dtime)
 	self.object:setacceleration(new_acc)
 	self.old_pos = vector.new(pos)
 	self.old_dir = vector.new(dir)
+	if self.old_dir.x ~= 0 or self.old_dir.y ~= 0 or self.old_dir.z ~= 0 then
+		self.last_nonzero_dir = self.old_dir
+	end
 	self.old_switch = last_switch
 
 


### PR DESCRIPTION
As currently written, if a cart completely stops moving on top of a power rail, then when the power rail is powered, the cart starts searching for which direction to move based on an arbitrary direction vector of (1,0,0). This pull request keeps track of the direction in which the cart was most recently moving, allowing the search to start from that direction instead. That means a cart that stops on straight track will resume motion in the same direction when the power rail is powered up. The last-nonzero-direction vector is persistent, so the cart will even move in the proper direction after a world save/load cycle.
